### PR TITLE
Fetch installable apps from api instead of currency list

### DIFF
--- a/src/components/ManagerPage/ManagerApp.js
+++ b/src/components/ManagerPage/ManagerApp.js
@@ -9,27 +9,39 @@ import Text from 'components/base/Text'
 const Container = styled(Box).attrs({
   align: 'center',
   justify: 'center',
-  m: 1,
+  m: 2,
 })`
   width: 150px;
   height: 150px;
-  background: rgba(0, 0, 0, 0.05);
+  background: white;
 `
+
+// https://api.ledgerwallet.com/update/assets/icons/bitcoin
 
 const ActionBtn = styled(Tabbable).attrs({
   fontSize: 3,
 })``
 
+const AppIcon = styled.img`
+  display: block;
+  width: 50px;
+  height: 50px;
+`
+
 type Props = {
   name: string,
+  icon: string,
   onInstall: Function,
   onUninstall: Function,
 }
 
 export default function ManagerApp(props: Props) {
-  const { name, onInstall, onUninstall } = props
+  const { name, icon, onInstall, onUninstall } = props
+  const iconUrl = `https://api.ledgerwallet.com/update/assets/icons/${icon}`
   return (
     <Container flow={3}>
+      <AppIcon src={iconUrl} />
+
       <Text ff="Museo Sans|Bold">{name}</Text>
       <Box horizontal flow={2}>
         <ActionBtn onClick={onInstall}>{'Install'}</ActionBtn>

--- a/src/components/ManagerPage/ManagerApp.js
+++ b/src/components/ManagerPage/ManagerApp.js
@@ -2,9 +2,6 @@
 
 import React from 'react'
 import styled from 'styled-components'
-import { getIconByCoinType } from '@ledgerhq/currencies/react'
-
-import type { Currency } from '@ledgerhq/currencies'
 
 import Box, { Tabbable } from 'components/base/Box'
 import Text from 'components/base/Text'
@@ -24,18 +21,16 @@ const ActionBtn = styled(Tabbable).attrs({
 })``
 
 type Props = {
-  currency: Currency,
+  name: string,
   onInstall: Function,
   onUninstall: Function,
 }
 
 export default function ManagerApp(props: Props) {
-  const { currency, onInstall, onUninstall } = props
-  const Icon = getIconByCoinType(currency.coinType)
+  const { name, onInstall, onUninstall } = props
   return (
     <Container flow={3}>
-      {Icon && <Icon size={24} />}
-      <Text>{currency.name}</Text>
+      <Text ff="Museo Sans|Bold">{name}</Text>
       <Box horizontal flow={2}>
         <ActionBtn onClick={onInstall}>{'Install'}</ActionBtn>
         <ActionBtn onClick={onUninstall}>{'Remove'}</ActionBtn>

--- a/src/components/ManagerPage/index.js
+++ b/src/components/ManagerPage/index.js
@@ -5,9 +5,7 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { translate } from 'react-i18next'
 import { compose } from 'redux'
-import { listCurrencies } from '@ledgerhq/currencies'
 
-import type { Currency } from '@ledgerhq/currencies'
 import type { Device } from 'types/common'
 
 import { runJob } from 'renderer/events'
@@ -18,8 +16,6 @@ import Box from 'components/base/Box'
 import Modal, { ModalBody } from 'components/base/Modal'
 
 import ManagerApp from './ManagerApp'
-
-const CURRENCIES = listCurrencies()
 
 const List = styled(Box).attrs({
   horizontal: true,
@@ -36,25 +32,54 @@ type Props = {
   device: Device,
 }
 
-type Status = 'idle' | 'busy' | 'success' | 'error'
+type Status = 'loading' | 'idle' | 'busy' | 'success' | 'error'
+
+type LedgerApp = {
+  name: string,
+  app: Object,
+}
 
 type State = {
   status: Status,
   error: string | null,
+  appsList: LedgerApp[],
 }
 
 class ManagerPage extends PureComponent<Props, State> {
   state = {
-    status: 'idle',
+    status: 'loading',
     error: null,
+    appsList: [],
   }
 
-  createDeviceJobHandler = options => (currency: Currency) => async () => {
+  componentDidMount() {
+    this.fetchList()
+  }
+
+  componentWillUnmount() {
+    this._unmounted = true
+  }
+
+  _unmounted = false
+
+  async fetchList() {
+    const appsList = await runJob({
+      channel: 'usb',
+      job: 'manager.listApps',
+      successResponse: 'manager.listAppsSuccess',
+      errorResponse: 'manager.listAppsError',
+    })
+    if (!this._unmounted) {
+      this.setState({ appsList, status: 'idle' })
+    }
+  }
+
+  createDeviceJobHandler = options => ({ app: appParams }) => async () => {
     this.setState({ status: 'busy' })
     try {
       const { job, successResponse, errorResponse } = options
       const { device: { path: devicePath } } = this.props
-      const data = { appName: currency.name.toLowerCase(), devicePath }
+      const data = { appParams, devicePath }
       await runJob({ channel: 'usb', job, successResponse, errorResponse, data })
       this.setState({ status: 'success' })
     } catch (err) {
@@ -78,10 +103,10 @@ class ManagerPage extends PureComponent<Props, State> {
 
   renderList = () => (
     <List>
-      {CURRENCIES.map(c => (
+      {this.state.appsList.map(c => (
         <ManagerApp
-          key={c.coinType}
-          currency={c}
+          key={c.name}
+          name={c.name}
           onInstall={this.handleInstall(c)}
           onUninstall={this.handleUninstall(c)}
         />
@@ -100,9 +125,17 @@ class ManagerPage extends PureComponent<Props, State> {
                 <Box fontSize={8}>{'Connect your device'}</Box>
               </Box>
             )}
-            {deviceStatus === 'connected' && this.renderList()}
+            {deviceStatus === 'connected' && (
+              <Box>
+                {status === 'loading' ? (
+                  <Box ff="Museo Sans|Bold">{'Loading app list...'}</Box>
+                ) : (
+                  this.renderList()
+                )}
+              </Box>
+            )}
             <Modal
-              isOpened={status !== 'idle'}
+              isOpened={status !== 'idle' && status !== 'loading'}
               render={() => (
                 <ModalBody p={6} align="center" justify="center" style={{ height: 300 }}>
                   {status === 'busy' ? (

--- a/src/components/ManagerPage/index.js
+++ b/src/components/ManagerPage/index.js
@@ -17,9 +17,13 @@ import Modal, { ModalBody } from 'components/base/Modal'
 
 import ManagerApp from './ManagerApp'
 
+const ICONS_FALLBACK = {
+  bitcoin_testnet: 'bitcoin',
+}
+
 const List = styled(Box).attrs({
   horizontal: true,
-  m: -1,
+  m: -2,
 })`
   flex-wrap: wrap;
 `
@@ -36,6 +40,7 @@ type Status = 'loading' | 'idle' | 'busy' | 'success' | 'error'
 
 type LedgerApp = {
   name: string,
+  icon: string,
   app: Object,
 }
 
@@ -107,6 +112,7 @@ class ManagerPage extends PureComponent<Props, State> {
         <ManagerApp
           key={c.name}
           name={c.name}
+          icon={ICONS_FALLBACK[c.icon] || c.icon}
           onInstall={this.handleInstall(c)}
           onUninstall={this.handleUninstall(c)}
         />

--- a/src/internals/usb/manager/constants.js
+++ b/src/internals/usb/manager/constants.js
@@ -1,17 +1,6 @@
 // Socket endpoint
 export const BASE_SOCKET_URL = 'ws://api.ledgerwallet.com/update/install'
 
-// Apparently params we need to add to websocket requests
-//
-// see https://github.com/LedgerHQ/ledger-manager-chrome
-//   > controllers/manager/ApplyUpdateController.scala
-//
-// @TODO: Get rid of them.
-export const DEFAULT_SOCKET_PARAMS = {
-  perso: 'perso_11',
-  hash: '0000000000000000000000000000000000000000000000000000000000000000',
-}
-
 // List of APDUS
 export const APDUS = {
   GET_FIRMWARE: [0xe0, 0x01, 0x00, 0x00],

--- a/src/internals/usb/manager/helpers.js
+++ b/src/internals/usb/manager/helpers.js
@@ -205,7 +205,9 @@ export async function getFirmwareInfo(transport: Transport<*>) {
 function log(namespace: string, str: string = '', color?: string) {
   namespace = namespace.padEnd(15)
   const coloredNamespace = color ? chalk[color](namespace) : namespace
-  console.log(`${chalk.bold(`> ${coloredNamespace}`)} ${str}`) // eslint-disable-line no-console
+  if (__DEV__) {
+    console.log(`${chalk.bold(`> ${coloredNamespace}`)} ${str}`) // eslint-disable-line no-console
+  }
 }
 
 /**

--- a/src/internals/usb/manager/index.js
+++ b/src/internals/usb/manager/index.js
@@ -17,6 +17,7 @@
  */
 
 import type { IPCSend } from 'types/electron'
+import axios from 'axios'
 import { createTransportHandler, installApp, uninstallApp } from './helpers'
 
 export default (send: IPCSend) => ({
@@ -31,4 +32,13 @@ export default (send: IPCSend) => ({
     successResponse: 'device.appUninstalled',
     errorResponse: 'device.appUninstallError',
   }),
+
+  listApps: async () => {
+    try {
+      const { data } = await axios.get('https://api.ledgerwallet.com/update/applications')
+      send('manager.listAppsSuccess', data['nanos-1.4'])
+    } catch (err) {
+      send('manager.listAppsError', { message: err.message, stack: err.stack })
+    }
+  },
 })

--- a/src/renderer/events.js
+++ b/src/renderer/events.js
@@ -56,7 +56,7 @@ export function runJob({
   job: string,
   successResponse: string,
   errorResponse: string,
-  data: any,
+  data?: any,
 }): Promise<void> {
   return new Promise((resolve, reject) => {
     ipcRenderer.send(channel, { type: job, data })


### PR DESCRIPTION
So now we have complete list of installable apps.
Still improvements to do:

- use device firmware for the request instead of hardcoded 1.4 Nano S (see https://github.com/LedgerHQ/ledger-wallet-desktop/commit/1512ec6b234ec31f911e8d15fae0178eca0ca1bb#diff-f2529adb08f0ad05b8c5cf48c8a577f3R39)
- map applications with our icons (either api side or in our side)

![2018-03-22_2018x984](https://user-images.githubusercontent.com/315259/37782709-dd1d5252-2df3-11e8-8a6e-4eee2806e756.png)
