### PR TITLE
simplify the Flow type of getAccountById

### DIFF
--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -81,9 +81,8 @@ export function getVisibleAccounts(state: { accounts: AccountsState }): Account[
   return getAccounts(state).filter(account => account.archived !== true)
 }
 
-export function getAccountById(state: { accounts: AccountsState }, id: string): Account | null {
-  const account = getAccounts(state).find(account => account.id === id)
-  return account || null
+export function getAccountById(state: { accounts: AccountsState }, id: string): ?Account {
+  return getAccounts(state).find(account => account.id === id)
 }
 
 export function canCreateAccount(state: State): boolean {


### PR DESCRIPTION
(just to give you feedback on that)

with flow `?T` will mean `T | undefined | null` I think anyway https://flow.org/en/docs/types/maybe/

In flow, you probably should never do `T | null` or `T | undefined` but just `?T`